### PR TITLE
 Fix Nil dereference error on empty result

### DIFF
--- a/lib/girlscout/list.rb
+++ b/lib/girlscout/list.rb
@@ -30,7 +30,7 @@ module GirlScout
     private
 
     def embedded_items
-      @embedded_items ||= @attributes['Embedded'].values[0]
+      @embedded_items ||= @attributes['Embedded']&.values&.first
     end
   end
 end

--- a/lib/girlscout/version.rb
+++ b/lib/girlscout/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GirlScout
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end


### PR DESCRIPTION
When no results are returned from a list query, the `first` accessor crashes