### PR TITLE
[NDPNTS-381] Update excon

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    girlscout (0.5.3)
+    girlscout (0.6.0)
       excon (~> 0.85)
       json (>= 1.8)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    girlscout (0.5.1)
-      excon (~> 0.71)
+    girlscout (0.5.3)
+      excon (~> 0.85)
       json (>= 1.8)
 
 GEM
@@ -13,7 +13,7 @@ GEM
     builder (3.2.4)
     childprocess (3.0.0)
     coderay (1.1.2)
-    excon (0.71.1)
+    excon (0.85.0)
     ffi (1.12.1)
     formatador (0.2.5)
     guard (2.16.1)
@@ -31,7 +31,7 @@ GEM
       minitest (>= 3.0)
     iniparse (1.4.4)
     jaro_winkler (1.5.4)
-    json (2.3.0)
+    json (2.5.1)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -91,4 +91,4 @@ DEPENDENCIES
   vcr (~> 5.0)
 
 BUNDLED WITH
-   2.0.2
+   2.2.25

--- a/girlscout.gemspec
+++ b/girlscout.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files -z lib`.split("\x0")
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'excon', '~>0.71'
+  s.add_runtime_dependency 'excon', '~>0.85'
   s.add_runtime_dependency 'json', '>=1.8'
 
   s.add_development_dependency 'bundler', '~>2.0'

--- a/lib/girlscout/version.rb
+++ b/lib/girlscout/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GirlScout
-  VERSION = '0.5.3'
+  VERSION = '0.6.0'
 end

--- a/test/girlscout/version.rb
+++ b/test/girlscout/version.rb
@@ -1,3 +1,3 @@
 module GirlScout
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
Upgrade package version 0.5 -> 0.6
needed to be able to upgrade the core gems including excon. so had to update excon in this gem as well
https://omise.atlassian.net/browse/NDPNTS-381