### PR TITLE
Test across Ruby versions using GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,27 @@
+name: Ruby
+
+on: 
+  push:
+    branches: [ 'master' ]
+  pull_request:
+    branches: [ 'master' ]
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+    name: Ruby ${{ matrix.ruby }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+
+    - name: Build and test with Rake
+      run: |
+        gem install bundler
+        bundle install --jobs 4 --retry 3
+        bundle exec rake test

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,17 +1,17 @@
 name: Ruby
 
-on: 
+on:
   push:
     branches: [ 'master' ]
   pull_request:
     branches: [ 'master' ]
-    
+
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.5', '2.6', '2.7' ] # listen-3.2.1 requires ruby version >= 2.2.7, ~> 2.2
     name: Ruby ${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GIRLSCOUT
 
+[![Ruby](https://github.com/omise/girlscout/actions/workflows/ruby.yml/badge.svg)](https://github.com/omise/girlscout/actions/workflows/ruby.yml)
+
 **BETA** This software is half-finished beta-quality software. Until 1.0 is released, use
 at your own risk!
 


### PR DESCRIPTION
Enable testing across Ruby versions using GitHub Actions. Skip 3.0 for now because of incompatible gem requirement.